### PR TITLE
Set up initial readme

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,6 +22,7 @@ repos:
         types: [text]
         stages: [commit, push, manual]
       - id: trailing-whitespace
+        args: [--markdown-linebreak-ext=md]
         name: Trim Trailing Whitespace
         entry: trailing-whitespace-fixer
         language: system

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,2 @@
+# Ignore all markdown files
+**/*.md

--- a/README.md
+++ b/README.md
@@ -12,6 +12,19 @@
 
 [Technical and working style guidelines](https://github.com/nestauk/ds-cookiecutter/blob/master/GUIDELINES.md)
 
+## Summary
+
+If the UK is to see a transition in home heating away from fossil fuel boilers, low carbon heating solutions, like heat pumps, will not only have to continue to grow in attractiveness among UK residents, but we'll also need a large, skilled and motivated installer workforce.
+
+In late 2023, [Nesta ran a survey of the installer community](https://www.nesta.org.uk/project/heat-pump-installer-survey/) supported by two industry experts: [Emma Bohan](https://www.imsheatpumps.co.uk/about-us-ims-heat-pump-installers/) and [Nathan Gambling](https://betatalk.buzzsprout.com/). The survey aimed to gather the opinions of those currently installing heat pumps in the UK so that we can know more about their experiences, challenges faced and areas where innovation can drive progress.
+
+This repo contains the code used to clean and preprocess the survey data and produce statistical summaries and analysis.
+
+## Nesta Personnel
+
+Project leads: [Oliver Zanetti](https://www.nesta.org.uk/team/oliver-zanetti/), [Shaan Jindal](https://www.nesta.org.uk/team/shaan-jindal/).  
+Analysis Support: [Daniel Lewis](https://www.nesta.org.uk/team/daniel-lewis/), [Oli Berry](https://www.nesta.org.uk/team/oli-berry/), [Benoit Siberdt](https://www.nesta.org.uk/team/benoit-siberdt/).  
+
 ---
 
 <small><p>Project based on <a target="_blank" href="https://github.com/nestauk/ds-cookiecutter">Nesta's data science project template</a>


### PR DESCRIPTION
No review required, branch used to setup basic initial readme for repo.

Note, a couple of non-standard precommit hooks introduced:
- git hook `trailing-whitespace` appended with `args: [--markdown-linebreak-ext=md]` to ignore markdown files.
- `.prettierignore` created and edited to ignore markdown files.